### PR TITLE
Allow to turn auto detection of HTML off.

### DIFF
--- a/src/main/java/io/rocketbase/commons/email/EmailTemplateBuilder.java
+++ b/src/main/java/io/rocketbase/commons/email/EmailTemplateBuilder.java
@@ -73,6 +73,26 @@ public final class EmailTemplateBuilder {
             return line;
         }
 
+        private TextLine addText(String textOrHtml, boolean asHtml) {
+            TextLine line = new TextLine(this, textOrHtml, asHtml);
+            templateLines.add(line);
+            return line;
+        }
+
+        /**
+         * @param html HTML formatted text
+         */
+        public TextLine addHtml(String html) {
+            return addText(html, true);
+        }
+
+        /**
+         * @param text text that shall be shown exactly as given - e.g. it will be encoded when it shall be shown as HTML
+         */
+        public TextLine addPlainText(String text) {
+            return addText(text, false);
+        }
+
         public ButtonLine addButton(String text, String url) {
             ButtonLine line = new ButtonLine(this, text, url);
             templateLines.add(line);
@@ -89,6 +109,20 @@ public final class EmailTemplateBuilder {
             FooterLine line = new FooterLine(this, textOrHtml);
             templateLines.add(line);
             return line;
+        }
+
+        private FooterLine addFooter(String textOrHtml, boolean asHtml) {
+            FooterLine line = new FooterLine(this, textOrHtml, asHtml);
+            templateLines.add(line);
+            return line;
+        }
+
+        public FooterLine addHtmlFooter(String html) {
+        	return addFooter(html, true);
+        }
+
+        public FooterLine addPlainTextFooter(String text) {
+        	return addFooter(text, true);
         }
 
         public CopyrightConfig copyright(String name) {

--- a/src/main/java/io/rocketbase/commons/email/FooterLine.java
+++ b/src/main/java/io/rocketbase/commons/email/FooterLine.java
@@ -10,6 +10,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 
+import com.google.common.html.HtmlEscapers;
+
 @Getter
 public class FooterLine implements TemplateLine {
 
@@ -26,7 +28,25 @@ public class FooterLine implements TemplateLine {
 
         Document doc = Jsoup.parse(text);
         this.asHtml = doc.body().children().size() > 0;
-        Elements links = doc.getElementsByTag("a");
+        handleTextAsHtml(doc);
+    }
+    
+    FooterLine(EmailTemplateConfigBuilder builder, String text, boolean asHtml) {
+        this.builder = builder;
+
+        this.asHtml = asHtml;
+        if (asHtml) {
+            Document doc = Jsoup.parse(text);
+            handleTextAsHtml(doc);
+        } else {
+            this.text = HtmlEscapers.htmlEscaper().escape(text);
+            
+            this.escapedText = text;
+        }
+    }
+
+    private void handleTextAsHtml(Document doc) {
+        Elements links = doc.body().getElementsByTag("a");
         links.forEach(e -> {
             if (e.attr("style").equals("")) {
                 // add correct styling for links

--- a/src/main/java/io/rocketbase/commons/email/TextLine.java
+++ b/src/main/java/io/rocketbase/commons/email/TextLine.java
@@ -10,6 +10,8 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 
+import com.google.common.html.HtmlEscapers;
+
 @Getter
 public class TextLine implements TemplateLine {
 
@@ -26,6 +28,24 @@ public class TextLine implements TemplateLine {
 
         Document doc = Jsoup.parse(text);
         this.asHtml = doc.body().children().size() > 0;
+        handleTextAsHtml(doc);
+    }
+
+    TextLine(EmailTemplateConfigBuilder builder, String text, boolean asHtml) {
+        this.builder = builder;
+
+        this.asHtml = asHtml;
+        if (asHtml) {
+            Document doc = Jsoup.parse(text);
+            handleTextAsHtml(doc);
+        } else {
+            this.text = HtmlEscapers.htmlEscaper().escape(text);
+            
+            this.escapedText = text;
+        }
+    }
+
+    private void handleTextAsHtml(Document doc) {
         Elements links = doc.body().getElementsByTag("a");
         links.forEach(e -> {
             if (e.attr("style").equals("")) {

--- a/src/test/java/io/rocketbase/commons/email/EmailTemplateBuilderTest.java
+++ b/src/test/java/io/rocketbase/commons/email/EmailTemplateBuilderTest.java
@@ -115,4 +115,52 @@ public class EmailTemplateBuilderTest {
                 .toString()
         ));
     }
+
+    @Test
+    public void forcedText() {
+        // given
+        EmailTemplateConfigBuilder builder = EmailTemplateBuilder.builder();
+        String header = "test";
+        ColorStyle headerStyle = new ColorStyle("000000", "ff0000");
+        // when
+        HtmlTextEmail htmlTextEmail = builder.header(header).color(headerStyle).and()
+                .addPlainText("sample <b>bold</b> text &Uuml;mlaut").and()
+                .build();
+        // then
+        assertThat(htmlTextEmail, notNullValue());
+        Document document = Jsoup.parse(htmlTextEmail.getHtml());
+        Element headerElement = document.getElementsByClass("alert-warning").get(0);
+        String style = headerElement.attr("style");
+        String text = headerElement.childNode(0).outerHtml();
+        assertThat(headerElement, notNullValue());
+        assertThat(style, containsString("background-color: #" + headerStyle.getBg()));
+        assertThat(style, containsString("color: #" + headerStyle.getText()));
+        assertThat(text, containsString(header));
+        assertThat(htmlTextEmail.getHtml(), containsString("sample &amp;lt;b&amp;gt;bold&amp;lt;/b&amp;gt; text &amp;amp;Uuml;mlaut"));
+        assertThat(htmlTextEmail.getText(), containsString("sample <b>bold</b> text &Uuml;mlaut"));
+    }
+
+    @Test
+    public void forcedHtml() {
+        // given
+        EmailTemplateConfigBuilder builder = EmailTemplateBuilder.builder();
+        String header = "test";
+        ColorStyle headerStyle = new ColorStyle("000000", "ff0000");
+        // when
+        HtmlTextEmail htmlTextEmail = builder.header(header).color(headerStyle).and()
+                .addHtml("sample <b>bold</b> text &Uuml;mlaut &lt; 17").and()
+                .build();
+        // then
+        assertThat(htmlTextEmail, notNullValue());
+        Document document = Jsoup.parse(htmlTextEmail.getHtml());
+        Element headerElement = document.getElementsByClass("alert-warning").get(0);
+        String style = headerElement.attr("style");
+        String text = headerElement.childNode(0).outerHtml();
+        assertThat(headerElement, notNullValue());
+        assertThat(style, containsString("background-color: #" + headerStyle.getBg()));
+        assertThat(style, containsString("color: #" + headerStyle.getText()));
+        assertThat(text, containsString(header));
+        assertThat(htmlTextEmail.getHtml(), containsString("sample \n<b>bold</b> text Ümlaut &lt; 17"));
+        assertThat(htmlTextEmail.getText(), containsString("sample bold text Ümlaut < 17"));
+    }
 }

--- a/src/test/java/io/rocketbase/commons/email/TextLineTest.java
+++ b/src/test/java/io/rocketbase/commons/email/TextLineTest.java
@@ -42,4 +42,52 @@ public class TextLineTest {
         assertThat(textLine.text, equalTo(input));
         assertThat(textLine.escapedText, equalTo(input));
     }
+
+    @Test
+    public void forceAsText() {
+        // given
+        String input = "sample <b>bold</b> text";
+        // when
+        TextLine textLine = new TextLine(null, input,false);
+        // then
+        assertThat(textLine.asHtml, equalTo(false));
+        assertThat(textLine.text, equalTo("sample &lt;b&gt;bold&lt;/b&gt; text"));
+        assertThat(textLine.escapedText, equalTo(input));
+    }
+
+    @Test
+    public void forceAsHtmlLineBreak() {
+        // given
+        String input = "sample text<br>with line break";
+        // when
+        TextLine textLine = new TextLine(null, input,true);
+        // then
+        assertThat(textLine.asHtml, equalTo(true));
+        assertThat(textLine.text, equalTo("sample text\n<br>with line break"));
+        assertThat(textLine.escapedText, equalTo("sample text\nwith line break"));
+    }
+
+    @Test
+    public void forceAsHtmlTags() {
+        // given
+        String input = "sample <b>bold</b> text";
+        // when
+        TextLine textLine = new TextLine(null, input,true);
+        // then
+        assertThat(textLine.asHtml, equalTo(true));
+        assertThat(textLine.text, equalTo("sample \n<b>bold</b> text"));
+        assertThat(textLine.escapedText, equalTo("sample bold text"));
+    }
+
+    @Test
+    public void forceAsHtmlQuoting() {
+        // given
+        String input = "sample &Uuml;mlaut text";
+        // when
+        TextLine textLine = new TextLine(null, input,true);
+        // then
+        assertThat(textLine.asHtml, equalTo(true));
+        assertThat(textLine.text, equalTo("sample Ümlaut text"));
+        assertThat(textLine.escapedText, equalTo("sample Ümlaut text"));
+    }
 }


### PR DESCRIPTION
When adding a line that is already correctly formatted as HTML, the auto
detection doesn't recognize this always correctly. E.g. the text
"&Uuml;mlaut" is interpreted as text.

So introduce a flag that tells whether the text is formatted as HTML or
not.