### PR TITLE
Fix attribute mutating instead of property mutating during AttributeLine.map()

### DIFF
--- a/email-template-builder/src/main/java/io/rocketbase/mail/AttributeLine.java
+++ b/email-template-builder/src/main/java/io/rocketbase/mail/AttributeLine.java
@@ -23,7 +23,7 @@ public class AttributeLine implements TemplateLine {
     }
 
     public AttributeLine map(Map<String, String> map) {
-        map.putAll(map);
+        this.map.putAll(map);
         return this;
     }
 

--- a/email-template-builder/src/test/java/io/rocketbase/mail/AttibuteLineTest.java
+++ b/email-template-builder/src/test/java/io/rocketbase/mail/AttibuteLineTest.java
@@ -1,0 +1,24 @@
+package io.rocketbase.mail;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Objects;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AttibuteLineTest {
+    @Test
+    public void standardTestHtml() {
+        // given
+        EmailTemplateBuilder.EmailTemplateConfigBuilder builder = EmailTemplateBuilder.builder();
+        AttributeLine attributes = builder
+                .attribute()
+                .map(new HashMap<String, String>() {{
+                    put("a", "b");
+                    put("c", "d");
+                }});
+        assertThat("Attributes are not empty", !attributes.map.isEmpty());
+        assertThat("Attributes have the correct values", Objects.equals(attributes.map.get("a"), "b") && Objects.equals(attributes.map.get("c"), "d"));
+    }
+}


### PR DESCRIPTION
I thought I was going crazy, or that the template was busted, until I saw this: 

![Screenshot 2023-03-13 at 7 31 07 PM](https://user-images.githubusercontent.com/174297/224877636-96d0f931-b4c8-41cf-9be0-66ebbff3c8d3.png)


Instead of this:

![Screenshot 2023-03-13 at 7 31 25 PM](https://user-images.githubusercontent.com/174297/224877675-6dd99265-c4dd-4941-a496-db7ee5479830.png)

This fixes the .map() function from not adding anything to the property.
